### PR TITLE
Add syllabus display/upload to course-description-box

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -305,6 +305,14 @@ body {
   margin: 10px 0;
 }
 
+.upload-syllabus-button {
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2rem;
+  padding: 0rem 0.7rem;
+}
+
 /*** Schedule ***/
 
 #schedule-table {

--- a/src/index.html
+++ b/src/index.html
@@ -359,40 +359,55 @@
       </div>
     </div>
 
-    <div class="modal fade" id="upload-syllabus-modal" tabindex="-1"> 
-      <div class="modal-dialog"> 
-          <div class="modal-content"> 
-              <div class="modal-header"> 
-                  <h5 class="modal-title">Upload Syllabus</h5> 
-                  <button type="button" class="close" data-dismiss="modal"> 
-                      <span>×</span> 
-                  </button> 
-              </div> 
-              <div class="modal-body" data-children-count="1"> 
-                  <p> This syllabus will be public. If you upload a new syllabus, it will replace any current course syllabus </p>  
-              <label for="semester-select">Choose a semester:</label>
-              <select id="semester-select">
-                  <option value="n/a">--N/A--</option>
-                  <option value="sp20">Spring 2020</option>
-                  <option value="fa19">Fall 2019</option>
-                  <option value="sp19">Spring 2019</option>
-                  <option value="fa18">Fall 2018</option>
-                  <option value="sp18">Spring 2018</option>
-                  <option value="fa17">Fall 2017</option>
-              </select>  
-              <br> 
-              <form action="/action_page.php">
-                  <input type="file" id="myFile" name="filename">
-              </form>
-              </div> 
-              <div class="modal-footer">   
-                  <button type="button" id="upload-syllabus-button" class="btn btn-primary"> Upload </button> 
-                  <button type="button" class="btn btn-secondary" data-dismiss="modal"> Close </button> 
-              </div>
-          </div> 
-      </div> 
-  </div>
-    
+    <div class="modal fade" id="upload-syllabus-modal" tabindex="-1">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Upload Syllabus</h5>
+            <button type="button" class="close" data-dismiss="modal">
+              <span>×</span>
+            </button>
+          </div>
+          <div class="modal-body" data-children-count="1">
+            <p>
+              This syllabus will be public. If you upload a new syllabus, it
+              will replace any current course syllabus
+            </p>
+            <label for="semester-select">Choose a semester:</label>
+            <select id="semester-select">
+              <option value="n/a">--N/A--</option>
+              <option value="sp20">Spring 2020</option>
+              <option value="fa19">Fall 2019</option>
+              <option value="sp19">Spring 2019</option>
+              <option value="fa18">Fall 2018</option>
+              <option value="sp18">Spring 2018</option>
+              <option value="fa17">Fall 2017</option>
+            </select>
+            <br />
+            <form action="/action_page.php">
+              <input type="file" id="myFile" name="filename" />
+            </form>
+          </div>
+          <div class="modal-footer">
+            <button
+              type="button"
+              id="upload-syllabus-button"
+              class="btn btn-primary"
+            >
+              Upload
+            </button>
+            <button
+              type="button"
+              class="btn btn-secondary"
+              data-dismiss="modal"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div class="modal fade" id="import-export-modal" tabindex="-1">
       <div class="modal-dialog">
         <div class="modal-content">

--- a/src/index.html
+++ b/src/index.html
@@ -359,6 +359,40 @@
       </div>
     </div>
 
+    <div class="modal fade" id="upload-syllabus-modal" tabindex="-1"> 
+      <div class="modal-dialog"> 
+          <div class="modal-content"> 
+              <div class="modal-header"> 
+                  <h5 class="modal-title">Upload Syllabus</h5> 
+                  <button type="button" class="close" data-dismiss="modal"> 
+                      <span>×</span> 
+                  </button> 
+              </div> 
+              <div class="modal-body" data-children-count="1"> 
+                  <p> This syllabus will be public. If you upload a new syllabus, it will replace any current course syllabus </p>  
+              <label for="semester-select">Choose a semester:</label>
+              <select id="semester-select">
+                  <option value="n/a">--N/A--</option>
+                  <option value="sp20">Spring 2020</option>
+                  <option value="fa19">Fall 2019</option>
+                  <option value="sp19">Spring 2019</option>
+                  <option value="fa18">Fall 2018</option>
+                  <option value="sp18">Spring 2018</option>
+                  <option value="fa17">Fall 2017</option>
+              </select>  
+              <br> 
+              <form action="/action_page.php">
+                  <input type="file" id="myFile" name="filename">
+              </form>
+              </div> 
+              <div class="modal-footer">   
+                  <button type="button" id="upload-syllabus-button" class="btn btn-primary"> Upload </button> 
+                  <button type="button" class="btn btn-secondary" data-dismiss="modal"> Close </button> 
+              </div>
+          </div> 
+      </div> 
+  </div>
+    
     <div class="modal fade" id="import-export-modal" tabindex="-1">
       <div class="modal-dialog">
         <div class="modal-content">

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1290,8 +1290,7 @@ function setCourseDescriptionBox(course) {
 
 function createSyllabusUploadBox(courseDescriptionBox) {
   const icon = document.createElement("i");
-  icon.classList.add("course-box-button");
-  icon.classList.add("course-box-add-button");
+  icon.classList.add("upload-syllabus-button");
   icon.classList.add("icon");
   icon.classList.add("ion-upload");
   icon.addEventListener("click", showUploadModal);
@@ -1303,9 +1302,9 @@ function createSyllabusUploadBox(courseDescriptionBox) {
   hreflink.value = "https://www.google.com";
   link.attributes.setNamedItem(hreflink);
   paragraph.appendChild(link);
+  paragraph.appendChild(icon);
 
   courseDescriptionBox.appendChild(paragraph);
-  courseDescriptionBox.appendChild(icon);
 }
 
 function minimizeCourseDescription() {

--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1256,6 +1256,11 @@ function showImportExportModal() {
   $("#import-export-modal").modal("show");
 }
 
+function showUploadModal() {
+  importExportTextArea.value = JSON.stringify(gSelectedCourses, 2);
+  $("#upload-syllabus-modal").modal("show");
+}
+
 function showSettingsModal() {
   $("#settings-modal").modal("show");
 }
@@ -1275,8 +1280,32 @@ function setCourseDescriptionBox(course) {
     paragraph.appendChild(text);
     courseDescriptionBox.appendChild(paragraph);
   }
+
+  courseDescriptionBox.appendChild(document.createElement("hr"));
+  createSyllabusUploadBox(courseDescriptionBox);
+
   minimizeArrowPointUp();
   courseDescriptionVisible();
+}
+
+function createSyllabusUploadBox(courseDescriptionBox) {
+  const icon = document.createElement("i");
+  icon.classList.add("course-box-button");
+  icon.classList.add("course-box-add-button");
+  icon.classList.add("icon");
+  icon.classList.add("ion-upload");
+  icon.addEventListener("click", showUploadModal);
+
+  const paragraph = document.createElement("p");
+  const link = document.createElement("a");
+  link.textContent = "Syllabus (2019)";
+  var hreflink = document.createAttribute("href");
+  hreflink.value = "https://www.google.com";
+  link.attributes.setNamedItem(hreflink);
+  paragraph.appendChild(link);
+
+  courseDescriptionBox.appendChild(paragraph);
+  courseDescriptionBox.appendChild(icon);
 }
 
 function minimizeCourseDescription() {


### PR DESCRIPTION
Add a new box containing a link to the syllabus (currently points to google.com) and the upload button. When the user clicks on the upload button, it shows a modal prompting a user to upload a file to the database. The database connection will be implemented in a stacked pull request.

<img width="300" alt="Screen Shot 2020-02-21 at 3 14 02 PM" src="https://user-images.githubusercontent.com/19219105/75079258-fa692100-54bc-11ea-9584-33046c27619f.png">
<img width="400" alt="Screen Shot 2020-02-21 at 3 14 08 PM" src="https://user-images.githubusercontent.com/19219105/75079259-fc32e480-54bc-11ea-9a7c-6c8c265f8a17.png">

Please squash the commits in this pull request.

Resolves the first task of #127. Worked with @JoaquinDoesCode