### PR TITLE
Make Timezone Changes Persist on Refresh

### DIFF
--- a/src/js/hyperschedule.js
+++ b/src/js/hyperschedule.js
@@ -1486,6 +1486,7 @@ function updateTimeZoneDropdown() {
   document.getElementById(
     "time-zone-dropdown-" + gTimeZoneId.toString()
   ).selected = true;
+  timeZoneDropdown.dispatchEvent(new Event("change"));
 }
 
 function updateCourseSearchResults() {


### PR DESCRIPTION
Before, the selected timezone persisted on refresh in the dropdown, but the actual schedule/course timings were still in Pacific time. I just made it so when the selected timezone is set on startup, it also fires an event as if the timezone has just been changed via dropdown to adjust all the course timings on startup.