### PR TITLE
added "show only non-conflicting sections" filter

### DIFF
--- a/frontend/src/components/course-search/CourseSearch.tsx
+++ b/frontend/src/components/course-search/CourseSearch.tsx
@@ -45,12 +45,16 @@ export default memo(function CourseSearch() {
             for (const selectedSection of selectedSections) {
                 // decide to have sections of the same course be non-conflicting with its own section
                 if (
+                    section.identifier.affiliation ===
+                        selectedSection.identifier.affiliation &&
                     section.identifier.courseNumber ===
-                    selectedSection.identifier.courseNumber
+                        selectedSection.identifier.courseNumber &&
+                    section.identifier.department ===
+                        selectedSection.identifier.department
                 ) {
                     return true;
-                } else {
-                    return !sectionsConflict(selectedSection, section);
+                } else if (sectionsConflict(selectedSection, section)) {
+                    return false;
                 }
             }
             return true;

--- a/frontend/src/components/course-search/CourseSearch.tsx
+++ b/frontend/src/components/course-search/CourseSearch.tsx
@@ -38,21 +38,17 @@ export default memo(function CourseSearch() {
         .filter((s) => s !== undefined) as APIv4.Section[];
 
     function getNonConflictingSections(
-        selectedSections: APIv4.Section[] | undefined,
-        sections: APIv4.Section[] | undefined,
-    ): APIv4.Section[] | undefined {
-        if (!sections) {
-            return undefined;
-        } else if (!selectedSections) {
-            return sections;
-        } else {
-            return sections.filter((section) => {
-                return selectedSections.some(
-                    (selectedSection) =>
-                        !sectionsConflict(selectedSection, section),
-                );
-            });
-        }
+        selectedSections: APIv4.Section[],
+        sections: APIv4.Section[],
+    ): APIv4.Section[] {
+        return sections.filter((section) => {
+            for (let selectedSection of selectedSections) {
+                if (sectionsConflict(selectedSection, section)) {
+                    return false;
+                }
+            }
+            return true;
+        });
     }
 
     const filteredSections: APIv4.Section[] | undefined = React.useMemo(() => {
@@ -86,7 +82,13 @@ export default memo(function CourseSearch() {
         return showOnlyNonConflicting
             ? getNonConflictingSections(selectedSections, sortedSections)
             : sortedSections;
-    }, [sections, searchText, searchFilters, showOnlyNonConflicting]);
+    }, [
+        sections,
+        searchText,
+        searchFilters,
+        selectedSections,
+        showOnlyNonConflicting,
+    ]);
 
     return (
         <div className={Css.container}>

--- a/frontend/src/components/course-search/CourseSearch.tsx
+++ b/frontend/src/components/course-search/CourseSearch.tsx
@@ -25,8 +25,8 @@ export default memo(function CourseSearch() {
     const searchText = useStore((store) => store.searchText);
     const searchFilters = useStore((store) => store.searchFilters);
     const areas = useCourseAreaDescription().data;
-    const showOnlyNonConflicting = useStore(
-        (store) => store.showOnlyNonConflicting,
+    const hideConflictingSections = useStore(
+        (store) => store.hideConflictingSections,
     );
     const activeSchedule = useActiveSchedule();
     const sectionsLookup = useActiveSectionsLookup();
@@ -65,7 +65,8 @@ export default memo(function CourseSearch() {
     }, [searchFilters, sections]);
 
     const sectionsToShow: APIv4.Section[] | undefined = React.useMemo(() => {
-        if (searchText === "") return filteredSections;
+        if (searchText === "" && !hideConflictingSections)
+            return filteredSections;
         if (filteredSections === undefined) return undefined;
 
         let res: [number, APIv4.Section][] = [];
@@ -79,7 +80,7 @@ export default memo(function CourseSearch() {
         const sorted = res.sort((a, b) => b[0] - a[0]);
         const sortedSections = sorted.map((a) => a[1]);
 
-        return showOnlyNonConflicting
+        return hideConflictingSections
             ? getNonConflictingSections(selectedSections, sortedSections)
             : sortedSections;
     }, [
@@ -87,7 +88,7 @@ export default memo(function CourseSearch() {
         searchText,
         searchFilters,
         selectedSections,
-        showOnlyNonConflicting,
+        hideConflictingSections,
     ]);
 
     return (

--- a/frontend/src/components/course-search/CourseSearch.tsx
+++ b/frontend/src/components/course-search/CourseSearch.tsx
@@ -42,9 +42,15 @@ export default memo(function CourseSearch() {
         sections: APIv4.Section[],
     ): APIv4.Section[] {
         return sections.filter((section) => {
-            for (let selectedSection of selectedSections) {
-                if (sectionsConflict(selectedSection, section)) {
-                    return false;
+            for (const selectedSection of selectedSections) {
+                // decide to have sections of the same course be non-conflicting with its own section
+                if (
+                    section.identifier.courseNumber ===
+                    selectedSection.identifier.courseNumber
+                ) {
+                    return true;
+                } else {
+                    return !sectionsConflict(selectedSection, section);
                 }
             }
             return true;

--- a/frontend/src/components/course-search/CourseSearch.tsx
+++ b/frontend/src/components/course-search/CourseSearch.tsx
@@ -13,7 +13,10 @@ import CourseRow from "@components/course-search/CourseRow";
 
 import Css from "./CourseSearch.module.css";
 import { memo, useCallback } from "react";
-import { useActiveSectionsLookup, useActiveSectionsQuery } from "@hooks/section";
+import {
+    useActiveSectionsLookup,
+    useActiveSectionsQuery,
+} from "@hooks/section";
 import { useActiveSchedule } from "@hooks/schedule";
 import { sectionsConflict } from "@lib/schedule";
 
@@ -22,7 +25,9 @@ export default memo(function CourseSearch() {
     const searchText = useStore((store) => store.searchText);
     const searchFilters = useStore((store) => store.searchFilters);
     const areas = useCourseAreaDescription().data;
-    const showOnlyNonConflicting = useStore((store) => store.showOnlyNonConflicting);
+    const showOnlyNonConflicting = useStore(
+        (store) => store.showOnlyNonConflicting,
+    );
     const activeSchedule = useActiveSchedule();
     const sectionsLookup = useActiveSectionsLookup();
     const selectedSections: APIv4.Section[] = activeSchedule?.sections
@@ -32,16 +37,20 @@ export default memo(function CourseSearch() {
         )
         .filter((s) => s !== undefined) as APIv4.Section[];
 
-    function getNonConflictingSections(selectedSections: APIv4.Section[] | undefined,
-        sections: APIv4.Section[] | undefined
+    function getNonConflictingSections(
+        selectedSections: APIv4.Section[] | undefined,
+        sections: APIv4.Section[] | undefined,
     ): APIv4.Section[] | undefined {
         if (!sections) {
             return undefined;
         } else if (!selectedSections) {
             return sections;
         } else {
-            return sections.filter(section => {
-                return selectedSections.some(selectedSection => !sectionsConflict(selectedSection, section));
+            return sections.filter((section) => {
+                return selectedSections.some(
+                    (selectedSection) =>
+                        !sectionsConflict(selectedSection, section),
+                );
             });
         }
     }

--- a/frontend/src/components/popup/Filter.module.css
+++ b/frontend/src/components/popup/Filter.module.css
@@ -1,9 +1,10 @@
 .title {
-    margin: 0;
+    margin: 0 0 0.25em 0;
 }
 
 .filterTable {
-    margin-top: 1.5em;
+    margin-top: 1.25em;
+    margin-bottom: 1.5em;
     display: grid;
     grid-template-columns: 1fr 1fr 2fr;
     grid-row-gap: 1em;

--- a/frontend/src/components/popup/Filter.tsx
+++ b/frontend/src/components/popup/Filter.tsx
@@ -5,6 +5,7 @@ import * as Search from "@lib/search";
 import useStore from "@hooks/store";
 import { memo, Fragment } from "react";
 import classNames from "classnames";
+import Slider from "@components/common/Slider";
 
 type FilterSpec = {
     name: string;
@@ -65,9 +66,21 @@ const filterSpecs: { [k in Search.FilterKey]: FilterSpec } = {
 export default memo(function Filter() {
     const setPopup = useStore((store) => store.setPopup);
     const addFilter = useStore((store) => store.addSearchFilter);
+    const showOnlyNonConflicting = useStore((store) => store.showOnlyNonConflicting);
+    const setShowOnlyNonConflicting = useStore((store) => store.setShowOnlyNonConflicting);
 
     return (
         <div>
+            <div>
+                <Slider
+                    value={showOnlyNonConflicting}
+                    text="show only non-conflicting sections"
+                    onToggle={() => {
+                        setShowOnlyNonConflicting(!showOnlyNonConflicting);
+                    }}
+                />
+            </div>
+
             <h2 className={Css.title}> Filters </h2>
             <div>
                 All filters are case-insensitive. When multiple filters are

--- a/frontend/src/components/popup/Filter.tsx
+++ b/frontend/src/components/popup/Filter.tsx
@@ -66,11 +66,11 @@ const filterSpecs: { [k in Search.FilterKey]: FilterSpec } = {
 export default memo(function Filter() {
     const setPopup = useStore((store) => store.setPopup);
     const addFilter = useStore((store) => store.addSearchFilter);
-    const hideConflictingSectionsOptions = useStore(
-        (store) => store.hideConflictingSectionsOptions,
+    const conflictingSectionsOptions = useStore(
+        (store) => store.conflictingSectionsOptions,
     );
-    const setHideConflictingSectionsOptions = useStore(
-        (store) => store.setHideConflictingSectionsOptions,
+    const setConflictingSectionsOptions = useStore(
+        (store) => store.setConflictingSectionsOptions,
     );
 
     return (
@@ -79,12 +79,12 @@ export default memo(function Filter() {
 
             <div>
                 <Slider
-                    value={hideConflictingSectionsOptions.selected}
+                    value={conflictingSectionsOptions.hidden}
                     text="Hide sections conflicting with schedule"
                     onToggle={() => {
-                        setHideConflictingSectionsOptions({
-                            ...hideConflictingSectionsOptions,
-                            selected: !hideConflictingSectionsOptions.selected,
+                        setConflictingSectionsOptions({
+                            ...conflictingSectionsOptions,
+                            hidden: !conflictingSectionsOptions.hidden,
                         });
                     }}
                 />

--- a/frontend/src/components/popup/Filter.tsx
+++ b/frontend/src/components/popup/Filter.tsx
@@ -75,6 +75,8 @@ export default memo(function Filter() {
 
     return (
         <div>
+            <h2 className={Css.title}> Filters </h2>
+
             <div>
                 <Slider
                     value={hideConflictingSections}
@@ -85,12 +87,6 @@ export default memo(function Filter() {
                 />
             </div>
 
-            <h2 className={Css.title}> Filters </h2>
-            <div>
-                All filters are case-insensitive. When multiple filters are
-                specified, only courses matching all the criteria will be shown
-                (logical AND).
-            </div>
             <div className={Css.filterTable}>
                 <span className={Css.tableHeader}>Filter for</span>
                 <span className={Css.tableHeader}>Type into search box</span>
@@ -142,6 +138,12 @@ export default memo(function Filter() {
                         </Fragment>
                     );
                 })}
+            </div>
+
+            <div>
+                All filters are case-insensitive. When multiple filters are
+                specified, only courses matching all the criteria will be shown
+                (logical AND).
             </div>
         </div>
     );

--- a/frontend/src/components/popup/Filter.tsx
+++ b/frontend/src/components/popup/Filter.tsx
@@ -78,7 +78,7 @@ export default memo(function Filter() {
             <div>
                 <Slider
                     value={showOnlyNonConflicting}
-                    text="show only non-conflicting sections"
+                    text="Hide sections conflicting with schedule"
                     onToggle={() => {
                         setShowOnlyNonConflicting(!showOnlyNonConflicting);
                     }}

--- a/frontend/src/components/popup/Filter.tsx
+++ b/frontend/src/components/popup/Filter.tsx
@@ -66,8 +66,12 @@ const filterSpecs: { [k in Search.FilterKey]: FilterSpec } = {
 export default memo(function Filter() {
     const setPopup = useStore((store) => store.setPopup);
     const addFilter = useStore((store) => store.addSearchFilter);
-    const showOnlyNonConflicting = useStore((store) => store.showOnlyNonConflicting);
-    const setShowOnlyNonConflicting = useStore((store) => store.setShowOnlyNonConflicting);
+    const showOnlyNonConflicting = useStore(
+        (store) => store.showOnlyNonConflicting,
+    );
+    const setShowOnlyNonConflicting = useStore(
+        (store) => store.setShowOnlyNonConflicting,
+    );
 
     return (
         <div>

--- a/frontend/src/components/popup/Filter.tsx
+++ b/frontend/src/components/popup/Filter.tsx
@@ -66,7 +66,7 @@ const filterSpecs: { [k in Search.FilterKey]: FilterSpec } = {
 export default memo(function Filter() {
     const setPopup = useStore((store) => store.setPopup);
     const addFilter = useStore((store) => store.addSearchFilter);
-    const { selected, alsoHideSectionsOfSelectedCourse } = useStore(
+    const hideConflictingSectionsOptions = useStore(
         (store) => store.hideConflictingSectionsOptions,
     );
     const setHideConflictingSectionsOptions = useStore(
@@ -79,13 +79,12 @@ export default memo(function Filter() {
 
             <div>
                 <Slider
-                    value={selected}
+                    value={hideConflictingSectionsOptions.selected}
                     text="Hide sections conflicting with schedule"
                     onToggle={() => {
                         setHideConflictingSectionsOptions({
-                            selected: !selected,
-                            alsoHideSectionsOfSelectedCourse:
-                                alsoHideSectionsOfSelectedCourse,
+                            ...hideConflictingSectionsOptions,
+                            selected: !hideConflictingSectionsOptions.selected,
                         });
                     }}
                 />

--- a/frontend/src/components/popup/Filter.tsx
+++ b/frontend/src/components/popup/Filter.tsx
@@ -66,11 +66,11 @@ const filterSpecs: { [k in Search.FilterKey]: FilterSpec } = {
 export default memo(function Filter() {
     const setPopup = useStore((store) => store.setPopup);
     const addFilter = useStore((store) => store.addSearchFilter);
-    const hideConflictingSections = useStore(
-        (store) => store.hideConflictingSections,
+    const { selected, alsoHideSectionsOfSelectedCourse } = useStore(
+        (store) => store.hideConflictingSectionsOptions,
     );
-    const setHideConflictingSections = useStore(
-        (store) => store.setHideConflictingSections,
+    const setHideConflictingSectionsOptions = useStore(
+        (store) => store.setHideConflictingSectionsOptions,
     );
 
     return (
@@ -79,10 +79,14 @@ export default memo(function Filter() {
 
             <div>
                 <Slider
-                    value={hideConflictingSections}
+                    value={selected}
                     text="Hide sections conflicting with schedule"
                     onToggle={() => {
-                        setHideConflictingSections(!hideConflictingSections);
+                        setHideConflictingSectionsOptions({
+                            selected: !selected,
+                            alsoHideSectionsOfSelectedCourse:
+                                alsoHideSectionsOfSelectedCourse,
+                        });
                     }}
                 />
             </div>

--- a/frontend/src/components/popup/Filter.tsx
+++ b/frontend/src/components/popup/Filter.tsx
@@ -66,21 +66,21 @@ const filterSpecs: { [k in Search.FilterKey]: FilterSpec } = {
 export default memo(function Filter() {
     const setPopup = useStore((store) => store.setPopup);
     const addFilter = useStore((store) => store.addSearchFilter);
-    const showOnlyNonConflicting = useStore(
-        (store) => store.showOnlyNonConflicting,
+    const hideConflictingSections = useStore(
+        (store) => store.hideConflictingSections,
     );
-    const setShowOnlyNonConflicting = useStore(
-        (store) => store.setShowOnlyNonConflicting,
+    const setHideConflictingSections = useStore(
+        (store) => store.setHideConflictingSections,
     );
 
     return (
         <div>
             <div>
                 <Slider
-                    value={showOnlyNonConflicting}
+                    value={hideConflictingSections}
                     text="Hide sections conflicting with schedule"
                     onToggle={() => {
-                        setShowOnlyNonConflicting(!showOnlyNonConflicting);
+                        setHideConflictingSections(!hideConflictingSections);
                     }}
                 />
             </div>

--- a/frontend/src/components/popup/Settings.module.css
+++ b/frontend/src/components/popup/Settings.module.css
@@ -28,6 +28,14 @@
         }
     }
 
+    & .filters {
+        @mixin two-column-grid;
+
+        & .title {
+            grid-column: 1 / -1;
+        }
+    }
+
     & .dataViewer {
         a,
         a:visited {

--- a/frontend/src/components/popup/Settings.tsx
+++ b/frontend/src/components/popup/Settings.tsx
@@ -21,6 +21,7 @@ export const Settings = memo(function Settings() {
         <div className={Css.settings}>
             <h2 className={Css.title}>Settings</h2>
             <AppearanceSettings />
+            <FilterSettings />
             <AccountSettings />
             <DataViewer />
             <ReportIssues />
@@ -183,6 +184,34 @@ const AppearanceSettings = memo(function AppearanceSettings() {
                     })
                 }
                 text=""
+            />
+        </div>
+    );
+});
+
+const FilterSettings = memo(function FilterSettings() {
+    const hideConflictingSectionsOptions = useStore(
+        (store) => store.hideConflictingSectionsOptions,
+    );
+    const setHideConflictingSectionsOptions = useStore(
+        (store) => store.setHideConflictingSectionsOptions,
+    );
+
+    return (
+        <div className={Css.filters}>
+            <h3 className={Css.title}>Filters</h3>
+            <Slider
+                value={
+                    hideConflictingSectionsOptions.alsoHideSectionsOfSelectedCourse
+                }
+                onToggle={() => {
+                    setHideConflictingSectionsOptions({
+                        ...hideConflictingSectionsOptions,
+                        alsoHideSectionsOfSelectedCourse:
+                            !hideConflictingSectionsOptions.alsoHideSectionsOfSelectedCourse,
+                    });
+                }}
+                text="Also hide other sections of the selected course when hiding the conflicting sections"
             />
         </div>
     );

--- a/frontend/src/components/popup/Settings.tsx
+++ b/frontend/src/components/popup/Settings.tsx
@@ -190,28 +190,26 @@ const AppearanceSettings = memo(function AppearanceSettings() {
 });
 
 const FilterSettings = memo(function FilterSettings() {
-    const hideConflictingSectionsOptions = useStore(
-        (store) => store.hideConflictingSectionsOptions,
+    const conflictingSectionsOptions = useStore(
+        (store) => store.conflictingSectionsOptions,
     );
-    const setHideConflictingSectionsOptions = useStore(
-        (store) => store.setHideConflictingSectionsOptions,
+    const setConflictingSectionsOptions = useStore(
+        (store) => store.setConflictingSectionsOptions,
     );
 
     return (
         <div className={Css.filters}>
-            <h3 className={Css.title}>Filters</h3>
+            <h3 className={Css.title}>Conflicting Sections</h3>
             <Slider
-                value={
-                    hideConflictingSectionsOptions.alsoHideSectionsOfSelectedCourse
-                }
+                value={conflictingSectionsOptions.skipSectionsOfSelectedCourse}
                 onToggle={() => {
-                    setHideConflictingSectionsOptions({
-                        ...hideConflictingSectionsOptions,
-                        alsoHideSectionsOfSelectedCourse:
-                            !hideConflictingSectionsOptions.alsoHideSectionsOfSelectedCourse,
+                    setConflictingSectionsOptions({
+                        ...conflictingSectionsOptions,
+                        skipSectionsOfSelectedCourse:
+                            !conflictingSectionsOptions.skipSectionsOfSelectedCourse,
                     });
                 }}
-                text="Also hide other sections of the selected course when hiding the conflicting sections"
+                text="Skip checking sections of selected courses"
             />
         </div>
     );

--- a/frontend/src/hooks/store/index.ts
+++ b/frontend/src/hooks/store/index.ts
@@ -20,7 +20,7 @@ export type Store = WithSetters<{
     mainTab: MainTab;
     searchText: string;
     searchFilters: StoreFilter[];
-    hideConflictingSectionsOptions: HideConflictingSectionsOptions;
+    conflictingSectionsOptions: ConflictingSectionsOptions;
     expandKey: APIv4.SectionIdentifier | null;
     expandHeight: number;
 
@@ -58,9 +58,9 @@ export type AppearanceOptions = {
     disableAnimations: boolean;
 };
 
-export type HideConflictingSectionsOptions = {
-    selected: boolean;
-    alsoHideSectionsOfSelectedCourse: boolean;
+export type ConflictingSectionsOptions = {
+    hidden: boolean;
+    skipSectionsOfSelectedCourse: boolean;
 };
 
 const initStore: Zustand.StateCreator<Store> = (set, get) => {
@@ -136,12 +136,12 @@ const initStore: Zustand.StateCreator<Store> = (set, get) => {
         setScheduleRenderingOptions: (options) =>
             set({ scheduleRenderingOptions: options }),
 
-        hideConflictingSectionsOptions: {
-            selected: false,
-            alsoHideSectionsOfSelectedCourse: false,
+        conflictingSectionsOptions: {
+            hidden: false,
+            skipSectionsOfSelectedCourse: true,
         },
-        setHideConflictingSectionsOptions: (options) =>
-            set({ hideConflictingSectionsOptions: options }),
+        setConflictingSectionsOptions: (options) =>
+            set({ conflictingSectionsOptions: options }),
     };
 };
 

--- a/frontend/src/hooks/store/index.ts
+++ b/frontend/src/hooks/store/index.ts
@@ -22,7 +22,10 @@ export type Store = WithSetters<{
     searchFilters: StoreFilter[];
 
     //TODO: have an option for this!
-    hideConflictingSections: boolean;
+    hideConflictingSectionsOptions: {
+        selected: boolean;
+        alsoHideSectionsOfSelectedCourse: boolean;
+    };
 
     expandKey: APIv4.SectionIdentifier | null;
     expandHeight: number;
@@ -134,9 +137,12 @@ const initStore: Zustand.StateCreator<Store> = (set, get) => {
         setScheduleRenderingOptions: (options) =>
             set({ scheduleRenderingOptions: options }),
 
-        hideConflictingSections: false,
-        setHideConflictingSections: (hideConflictingSections) =>
-            set({ hideConflictingSections: hideConflictingSections }),
+        hideConflictingSectionsOptions: {
+            selected: false,
+            alsoHideSectionsOfSelectedCourse: false,
+        },
+        setHideConflictingSectionsOptions: (options) =>
+            set({ hideConflictingSectionsOptions: options }),
     };
 };
 

--- a/frontend/src/hooks/store/index.ts
+++ b/frontend/src/hooks/store/index.ts
@@ -132,7 +132,8 @@ const initStore: Zustand.StateCreator<Store> = (set, get) => {
             set({ scheduleRenderingOptions: options }),
 
         showOnlyNonConflicting: false,
-        setShowOnlyNonConflicting: (showOnlyNonConflicting) => set({ showOnlyNonConflicting }),
+        setShowOnlyNonConflicting: (showOnlyNonConflicting) =>
+            set({ showOnlyNonConflicting }),
     };
 };
 

--- a/frontend/src/hooks/store/index.ts
+++ b/frontend/src/hooks/store/index.ts
@@ -20,13 +20,10 @@ export type Store = WithSetters<{
     mainTab: MainTab;
     searchText: string;
     searchFilters: StoreFilter[];
-
-    //TODO: have an option for this!
     hideConflictingSectionsOptions: {
         selected: boolean;
         alsoHideSectionsOfSelectedCourse: boolean;
     };
-
     expandKey: APIv4.SectionIdentifier | null;
     expandHeight: number;
 

--- a/frontend/src/hooks/store/index.ts
+++ b/frontend/src/hooks/store/index.ts
@@ -20,10 +20,7 @@ export type Store = WithSetters<{
     mainTab: MainTab;
     searchText: string;
     searchFilters: StoreFilter[];
-    hideConflictingSectionsOptions: {
-        selected: boolean;
-        alsoHideSectionsOfSelectedCourse: boolean;
-    };
+    hideConflictingSectionsOptions: HideConflictingSectionsOptions;
     expandKey: APIv4.SectionIdentifier | null;
     expandHeight: number;
 
@@ -59,6 +56,11 @@ export type AppearanceOptions = {
     disableTransparency: boolean;
     disableRoundedCorners: boolean;
     disableAnimations: boolean;
+};
+
+export type HideConflictingSectionsOptions = {
+    selected: boolean;
+    alsoHideSectionsOfSelectedCourse: boolean;
 };
 
 const initStore: Zustand.StateCreator<Store> = (set, get) => {

--- a/frontend/src/hooks/store/index.ts
+++ b/frontend/src/hooks/store/index.ts
@@ -20,7 +20,10 @@ export type Store = WithSetters<{
     mainTab: MainTab;
     searchText: string;
     searchFilters: StoreFilter[];
+
+    //TODO: have an option for this!
     hideConflictingSections: boolean;
+
     expandKey: APIv4.SectionIdentifier | null;
     expandHeight: number;
 

--- a/frontend/src/hooks/store/index.ts
+++ b/frontend/src/hooks/store/index.ts
@@ -20,6 +20,7 @@ export type Store = WithSetters<{
     mainTab: MainTab;
     searchText: string;
     searchFilters: StoreFilter[];
+    showOnlyNonConflicting: boolean;
     expandKey: APIv4.SectionIdentifier | null;
     expandHeight: number;
 
@@ -129,6 +130,9 @@ const initStore: Zustand.StateCreator<Store> = (set, get) => {
         },
         setScheduleRenderingOptions: (options) =>
             set({ scheduleRenderingOptions: options }),
+
+        showOnlyNonConflicting: false,
+        setShowOnlyNonConflicting: (showOnlyNonConflicting) => set({ showOnlyNonConflicting }),
     };
 };
 

--- a/frontend/src/hooks/store/index.ts
+++ b/frontend/src/hooks/store/index.ts
@@ -20,7 +20,7 @@ export type Store = WithSetters<{
     mainTab: MainTab;
     searchText: string;
     searchFilters: StoreFilter[];
-    showOnlyNonConflicting: boolean;
+    hideConflictingSections: boolean;
     expandKey: APIv4.SectionIdentifier | null;
     expandHeight: number;
 
@@ -131,9 +131,9 @@ const initStore: Zustand.StateCreator<Store> = (set, get) => {
         setScheduleRenderingOptions: (options) =>
             set({ scheduleRenderingOptions: options }),
 
-        showOnlyNonConflicting: false,
-        setShowOnlyNonConflicting: (showOnlyNonConflicting) =>
-            set({ showOnlyNonConflicting }),
+        hideConflictingSections: false,
+        setHideConflictingSections: (hideConflictingSections) =>
+            set({ hideConflictingSections: hideConflictingSections }),
     };
 };
 


### PR DESCRIPTION
__Added a new slider option in the popup Filter: show only non-conflicting sections filter__

If the option is enabled, the filtered sections will only contain the sections that do not conflict with those already added to the user's current schedule.

Implementation Summary:
- add a state ```showOnlyNonConflicting``` to the ```useStore``` hook
- add a slider in the popup Filter for the user to choose the option
- retrieve the sections that are already in the user's schedule
- filter out of the conflicting sections in ```sectionsToShow``` before they get rendered to the UI