### PR TITLE
added option to also hide async sections

### DIFF
--- a/frontend/src/components/popup/Filter.tsx
+++ b/frontend/src/components/popup/Filter.tsx
@@ -66,11 +66,11 @@ const filterSpecs: { [k in Search.FilterKey]: FilterSpec } = {
 export default memo(function Filter() {
     const setPopup = useStore((store) => store.setPopup);
     const addFilter = useStore((store) => store.addSearchFilter);
-    const conflictingSectionsOptions = useStore(
-        (store) => store.conflictingSectionsOptions,
+    const hideConflictingSections = useStore(
+        (store) => store.hideConflictingSections,
     );
-    const setConflictingSectionsOptions = useStore(
-        (store) => store.setConflictingSectionsOptions,
+    const setHideConflictingSections = useStore(
+        (store) => store.setHideConflictingSections,
     );
 
     return (
@@ -79,13 +79,10 @@ export default memo(function Filter() {
 
             <div>
                 <Slider
-                    value={conflictingSectionsOptions.hidden}
+                    value={hideConflictingSections}
                     text="Hide sections conflicting with schedule"
                     onToggle={() => {
-                        setConflictingSectionsOptions({
-                            ...conflictingSectionsOptions,
-                            hidden: !conflictingSectionsOptions.hidden,
-                        });
+                        setHideConflictingSections(!hideConflictingSections);
                     }}
                 />
             </div>

--- a/frontend/src/components/popup/Settings.module.css
+++ b/frontend/src/components/popup/Settings.module.css
@@ -28,7 +28,7 @@
         }
     }
 
-    & .filters {
+    & .sectionConflict {
         @mixin two-column-grid;
 
         & .title {

--- a/frontend/src/components/popup/Settings.tsx
+++ b/frontend/src/components/popup/Settings.tsx
@@ -21,7 +21,7 @@ export const Settings = memo(function Settings() {
         <div className={Css.settings}>
             <h2 className={Css.title}>Settings</h2>
             <AppearanceSettings />
-            <FilterSettings />
+            <SectionConflictSettings />
             <AccountSettings />
             <DataViewer />
             <ReportIssues />
@@ -189,7 +189,7 @@ const AppearanceSettings = memo(function AppearanceSettings() {
     );
 });
 
-const FilterSettings = memo(function FilterSettings() {
+const SectionConflictSettings = memo(function SectionConflictSettings() {
     const conflictingSectionsOptions = useStore(
         (store) => store.conflictingSectionsOptions,
     );
@@ -198,8 +198,9 @@ const FilterSettings = memo(function FilterSettings() {
     );
 
     return (
-        <div className={Css.filters}>
-            <h3 className={Css.title}>Conflicting Sections</h3>
+        <div className={Css.sectionConflict}>
+            <h3 className={Css.title}>Section Conflict</h3>
+            <span>Skip checking sections of selected courses</span>
             <Slider
                 value={conflictingSectionsOptions.skipSectionsOfSelectedCourse}
                 onToggle={() => {
@@ -209,7 +210,19 @@ const FilterSettings = memo(function FilterSettings() {
                             !conflictingSectionsOptions.skipSectionsOfSelectedCourse,
                     });
                 }}
-                text="Skip checking sections of selected courses"
+                text=""
+            />
+            <span>Also hide asynchronous sections</span>
+            <Slider
+                value={conflictingSectionsOptions.hideAsyncSections}
+                onToggle={() => {
+                    setConflictingSectionsOptions({
+                        ...conflictingSectionsOptions,
+                        hideAsyncSections:
+                            !conflictingSectionsOptions.hideAsyncSections,
+                    });
+                }}
+                text=""
             />
         </div>
     );

--- a/frontend/src/hooks/store/index.ts
+++ b/frontend/src/hooks/store/index.ts
@@ -20,6 +20,7 @@ export type Store = WithSetters<{
     mainTab: MainTab;
     searchText: string;
     searchFilters: StoreFilter[];
+    hideConflictingSections: boolean;
     conflictingSectionsOptions: ConflictingSectionsOptions;
     expandKey: APIv4.SectionIdentifier | null;
     expandHeight: number;
@@ -59,7 +60,6 @@ export type AppearanceOptions = {
 };
 
 export type ConflictingSectionsOptions = {
-    hidden: boolean;
     skipSectionsOfSelectedCourse: boolean;
     hideAsyncSections: boolean;
 };
@@ -137,10 +137,11 @@ const initStore: Zustand.StateCreator<Store> = (set, get) => {
         setScheduleRenderingOptions: (options) =>
             set({ scheduleRenderingOptions: options }),
 
-        // TODO: add hide async classes
-        // checking for async -> start-time == end-time || no day (empty array)
+        hideConflictingSections: false,
+        setHideConflictingSections: (hideConflictingSections) =>
+            set({ hideConflictingSections }),
+
         conflictingSectionsOptions: {
-            hidden: false,
             skipSectionsOfSelectedCourse: false,
             hideAsyncSections: false,
         },
@@ -158,6 +159,7 @@ const useStore = Zustand.create<Store>()(
                 "scheduleRenderingOptions",
                 "theme",
                 "appearanceOptions",
+                "conflictingSectionsOptions",
             ),
         }),
     ),

--- a/frontend/src/hooks/store/index.ts
+++ b/frontend/src/hooks/store/index.ts
@@ -61,6 +61,7 @@ export type AppearanceOptions = {
 export type ConflictingSectionsOptions = {
     hidden: boolean;
     skipSectionsOfSelectedCourse: boolean;
+    hideAsyncSections: boolean;
 };
 
 const initStore: Zustand.StateCreator<Store> = (set, get) => {
@@ -136,9 +137,12 @@ const initStore: Zustand.StateCreator<Store> = (set, get) => {
         setScheduleRenderingOptions: (options) =>
             set({ scheduleRenderingOptions: options }),
 
+        // TODO: add hide async classes
+        // checking for async -> start-time == end-time || no day (empty array)
         conflictingSectionsOptions: {
             hidden: false,
-            skipSectionsOfSelectedCourse: true,
+            skipSectionsOfSelectedCourse: false,
+            hideAsyncSections: false,
         },
         setConflictingSectionsOptions: (options) =>
             set({ conflictingSectionsOptions: options }),


### PR DESCRIPTION
Added another option in Section Conflict that ask if the user also want to hide async sections when the an option hide the conflicting sections is selected.

Also, fixed some default behavior of the Section Conflict from previous deployment