### PR TITLE
add a span to work around oversized dropdown on safari

### DIFF
--- a/frontend/src/components/course-search/CourseSearch.tsx
+++ b/frontend/src/components/course-search/CourseSearch.tsx
@@ -395,18 +395,22 @@ const MultiTermsSearchMenu = memo(function MultiTermsSearchMenu() {
                             (this may affect performance!)
                         </span>
                     </span>
-                    <Dropdown
-                        choices={rangeOptions.map((range) => range.toString())}
-                        selected={multiTermsSearchOptions.range.toString()}
-                        onSelect={(index) => {
-                            const selectedRange = rangeOptions[index] ?? 4;
-                            setMultiTermsSearchOptions({
-                                ...multiTermsSearchOptions,
-                                range: selectedRange,
-                            });
-                        }}
-                        emptyPlaceholder={"none selected"}
-                    />
+                    <span>
+                        <Dropdown
+                            choices={rangeOptions.map((range) =>
+                                range.toString(),
+                            )}
+                            selected={multiTermsSearchOptions.range.toString()}
+                            onSelect={(index) => {
+                                const selectedRange = rangeOptions[index] ?? 4;
+                                setMultiTermsSearchOptions({
+                                    ...multiTermsSearchOptions,
+                                    range: selectedRange,
+                                });
+                            }}
+                            emptyPlaceholder={"none selected"}
+                        />
+                    </span>
                 </div>
             ) : (
                 <></>


### PR DESCRIPTION
fix the the buggy Dropdown rendering on safari by putting in a <span></span>