### PR TITLE
Set Background Color on Dropdowns

### DIFF
--- a/frontend/src/components/common/Dropdown.module.css
+++ b/frontend/src/components/common/Dropdown.module.css
@@ -20,6 +20,7 @@
 
         background-color: transparent;
         color: var(--fg-0);
+        background-color: var(--bg-0);
         transition: color var(--misc-transition-duration);
 
         & option:disabled {

--- a/frontend/src/components/common/Dropdown.module.css
+++ b/frontend/src/components/common/Dropdown.module.css
@@ -18,7 +18,6 @@
         width: 100%;
         height: 100%;
 
-        background-color: transparent;
         color: var(--fg-0);
         background-color: var(--bg-0);
         transition: color var(--misc-transition-duration);


### PR DESCRIPTION
Currently, the background color on dropdown menus is unset. This leads to the background occasionally being white in dark-mode (ex. on the term selection dropdown), making the text in the dropdown hard to read. This PR explicitly sets the background color to the background color variable, fixing this issue.