### PR TITLE
Move Theme Slider

### DIFF
--- a/frontend/src/components/SelectedList.module.css
+++ b/frontend/src/components/SelectedList.module.css
@@ -12,6 +12,7 @@
         display: flex;
         width: 100%;
         justify-content: space-evenly;
+        height: 3rem;
     }
 
     &.isDragging {

--- a/frontend/src/components/SelectedList.tsx
+++ b/frontend/src/components/SelectedList.tsx
@@ -194,7 +194,7 @@ export default memo(function SelectedList() {
                     </DndCore.DndContext>
                     {scheduleRenderingOptions.showConflicting ||
                     activeSchedule.sections.length === 0 ? (
-                        <></>
+                        <div className={Css.textContainer}></div>
                     ) : (
                         <div className={Css.textContainer}>
                             <span>(drag sections to change priorities)</span>


### PR DESCRIPTION
At the moment, the theme slider sits on top of the currently selected courses list. This makes it impossible to remove the last course in the list without first shifting it up 1 position so the delete button is exposed.

This PR moves the slider to the top of the sidebar panel so that the slider does not obstruct any GUI elements.