### PR TITLE
Fix Pre-Commit Hook When Auto-CRLF is Enabled

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text eol=lf
+* text=auto eol=lf


### PR DESCRIPTION
Prettier expects files to have `lf` line endings, but when the pre-commit hook runs `git stash`, all the `lf` endings are replaced with `crlf` if `autocrlf` is enabled. As a result, the pre-commit hook fails even after running prettier. This PR forces `autocrlf=lf`, disabling this behavior.