### PR TITLE
fix: bug where calendar export ends a day early 🐛

### DIFF
--- a/backend/src/routes/v4/calendar.ts
+++ b/backend/src/routes/v4/calendar.ts
@@ -193,7 +193,7 @@ function createRRule(endDate: APIv4.CourseDate, days: APIv4.Weekday[]): string {
     const daysString = days.map(weekdayToRRuleDay).join(",");
     const monthString = String(endDate.month).padStart(2, "0");
     const dayString = String(endDate.day).padStart(2, "0");
-    const endString = `${endDate.year}${monthString}${dayString}T000000`;
+    const endString = `${endDate.year}${monthString}${dayString}T235959`;
     return (
         `FREQ=WEEKLY;` +
         `INTERVAL=1;` +


### PR DESCRIPTION
Fixes #222 .

More work however will be required in the future for calendar export, which I will do in a later PR. We can add exceptions to the RRULE based on days where there are no classes. See link below for more information.

https://www.hmc.edu/registrar/academic-calendar/4-year-projected-calendar/
