### PR TITLE
Add libcrypto dep to fix CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install libcrypto.so.1.1 for MongoDB
         if: matrix.command == 'test'
         run: |
-          wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
+          wget https://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
           sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
       - name: Install dependencies
         run: yarn install --immutable

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         # we use matrix so we can run those in parallel
@@ -23,6 +23,11 @@ jobs:
         with:
           node-version: 18
           cache: "yarn"
+      - name: Install libcrypto.so.1.1 for MongoDB
+        if: matrix.command == 'test'
+        run: |
+          wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
+          sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
       - name: Install dependencies
         run: yarn install --immutable
       - name: Run ${{matrix.command}}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         # we use matrix so we can run those in parallel


### PR DESCRIPTION
Lot of larger issues here that will need to be fixed later, this is just a short term bandaid solution.

Will want to upgrade node version, and then bump the mongodbmemoryserver version, and then resolve a bunch of dependencies and typechecks that cause everything else to fail when versions are bumped 