### PR TITLE
Fix/multiterm search optimization

### DIFF
--- a/base.dockerfile
+++ b/base.dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bullseye
+FROM node:22-bullseye
 
 # install the linux version of all dependencies
 RUN apt update && apt install -y git

--- a/frontend/src/components/course-search/CourseSearch.tsx
+++ b/frontend/src/components/course-search/CourseSearch.tsx
@@ -99,11 +99,23 @@ export default memo(function CourseSearch() {
     const { enable, range } = useStore(
         (store) => store.multiTermsSearchOptions,
     );
+    const setMultiTermsSearchOptions = useStore(
+        (store) => store.setMultiTermsSearchOptions,
+    );
     const allTerms = useAllTerms() ?? [];
     const multiTermsSections = useSectionsForTermsQuery(
         enable,
         allTerms.slice(0, range),
     ).data;
+
+    React.useEffect(() => {
+        if (enable) {
+            setMultiTermsSearchOptions({
+                range: range,
+                enable: false,
+            });
+        }
+    }, [searchText]);
 
     const matchingMultiTermsSections: APIv4.Section[] | undefined =
         React.useMemo(() => {


### PR DESCRIPTION
# Problem
- Multi-term search is kept enabled once the user turns it on
- If the searchText is changed to match a lot of sections (from many recent terms), we have to filter a huge load of sections and require the UI to render such huge numbers of elements

# Fix
- Automatically disable the multi-term search feature once the searchText changes and let the user turn it on once they want to look for more sections again.

# Miscellaneous 
- I bumped the base Dockerfile to use node22 rather than 18; this should not effect GitHub action testing only for local dev