### PR TITLE
feat: add copy course code functionality for portal registration

### DIFF
--- a/frontend/src/components/SelectedList.module.css
+++ b/frontend/src/components/SelectedList.module.css
@@ -137,6 +137,18 @@
             font-weight: bold;
             min-width: 8.5em;
             font-size: 0.875em;
+            cursor: pointer;
+            padding: 0.125rem 0.25rem;
+            border-radius: 0.25rem;
+            transition: background-color 200ms;
+
+            &:hover {
+                background-color: #0001;
+            }
+
+            &:active {
+                background-color: #0002;
+            }
         }
 
         & .title {

--- a/frontend/src/components/SelectedList.tsx
+++ b/frontend/src/components/SelectedList.tsx
@@ -18,6 +18,7 @@ import { useUserStore } from "@hooks/store/user";
 import Css from "./SelectedList.module.css";
 import SectionStatusBadge from "@components/common/SectionStatusBadge";
 import { toast } from "react-toastify";
+import { copyBasicCourseCode, formatCourseCodeForPortal } from "@lib/clipboard";
 
 import * as Schedule from "@lib/schedule";
 import classNames from "classnames";
@@ -294,7 +295,16 @@ const SectionEntry = memo(function SectionEntry(props: {
                     });
                 }}
             >
-                <span className={Css.code}>
+                <span
+                    className={Css.code}
+                    onClick={(event) => {
+                        event.stopPropagation();
+                        copyBasicCourseCode(props.entry.section);
+                    }}
+                    title={`Click to copy: ${formatCourseCodeForPortal(
+                        props.entry.section,
+                    )}`}
+                >
                     {APIv4.stringifySectionCode(props.entry.section)}{" "}
                 </span>
                 <span className={Css.title}>

--- a/frontend/src/components/course-search/CourseRow.module.css
+++ b/frontend/src/components/course-search/CourseRow.module.css
@@ -140,6 +140,21 @@
             opacity: 0.875;
             min-width: 8.5em;
             text-align: left;
+            cursor: pointer;
+            padding: 0.125rem 0.25rem;
+            border-radius: 0.25rem;
+            transition:
+                background-color 200ms,
+                opacity 200ms;
+
+            &:hover {
+                opacity: 1;
+                background-color: #0001;
+            }
+
+            &:active {
+                background-color: #0002;
+            }
         }
 
         & .affiliation {

--- a/frontend/src/components/course-search/CourseRow.tsx
+++ b/frontend/src/components/course-search/CourseRow.tsx
@@ -19,6 +19,7 @@ import { toast } from "react-toastify";
 import { PopupOption } from "@lib/popup";
 import { pick } from "@lib/store";
 import { DEFAULT_LOCAL_SCHEDULE_ID } from "@lib/constants";
+import { copyBasicCourseCode, formatCourseCodeForPortal } from "@lib/clipboard";
 import { memo } from "react";
 
 export default memo(function CourseRow(props: {
@@ -52,11 +53,7 @@ export default memo(function CourseRow(props: {
                     <div className={Css.titlebar} onClick={props.onClick}>
                         <Feather.Archive className={Css.archive} size={14} />
                         <span className={Css.summary}>
-                            <span className={Css.courseNumber}>
-                                {APIv4.stringifySectionCode(
-                                    props.section.identifier,
-                                )}
-                            </span>
+                            <CopyCodeSpan section={props.section.identifier} />
                             <span className={Css.title}>
                                 {props.section.course.title}
                             </span>
@@ -94,11 +91,7 @@ export default memo(function CourseRow(props: {
                 <div className={Css.titlebar} onClick={props.onClick}>
                     <Feather.ChevronRight className={Css.arrow} size={14} />
                     <span className={Css.summary}>
-                        <span className={Css.courseNumber}>
-                            {APIv4.stringifySectionCode(
-                                props.section.identifier,
-                            )}
-                        </span>
+                        <CopyCodeSpan section={props.section.identifier} />
                         <span className={Css.title}>
                             {props.section.course.title}
                         </span>
@@ -224,5 +217,24 @@ const ToggleButton = memo(function ToggleButton(props: {
         >
             {inSchedule ? <Feather.X size={14} /> : <Feather.Plus size={14} />}
         </button>
+    );
+});
+
+const CopyCodeSpan = memo(function CopyCodeSpan(props: {
+    section: APIv4.SectionIdentifier;
+}) {
+    const handleCopy = (event: React.MouseEvent) => {
+        event.stopPropagation();
+        copyBasicCourseCode(props.section);
+    };
+
+    return (
+        <span
+            className={Css.courseNumber}
+            onClick={handleCopy}
+            title={`Click to copy: ${formatCourseCodeForPortal(props.section)}`}
+        >
+            {APIv4.stringifySectionCode(props.section)}
+        </span>
     );
 });

--- a/frontend/src/components/popup/SectionDetails.module.css
+++ b/frontend/src/components/popup/SectionDetails.module.css
@@ -1,5 +1,17 @@
 .content {
     & .sectionTitle {
         margin: 0.5em 0;
+        cursor: pointer;
+        padding: 0.25rem;
+        border-radius: 0.25rem;
+        transition: background-color 200ms;
+
+        &:hover {
+            background-color: #0001;
+        }
+
+        &:active {
+            background-color: #0002;
+        }
     }
 }

--- a/frontend/src/components/popup/SectionDetails.tsx
+++ b/frontend/src/components/popup/SectionDetails.tsx
@@ -2,6 +2,7 @@ import * as APIv4 from "hyperschedule-shared/api/v4";
 import Css from "./SectionDetails.module.css";
 import CourseDescriptionBox from "@components/course-search/CourseDescriptionBox";
 import { useUserStore } from "@hooks/store/user";
+import { copyBasicCourseCode, formatCourseCodeForPortal } from "@lib/clipboard";
 import { memo } from "react";
 
 export default memo(function SectionDetails(props: {
@@ -16,7 +17,13 @@ export default memo(function SectionDetails(props: {
         activeTerm.year === props.section.identifier.year;
     return (
         <div className={Css.content}>
-            <h3 className={Css.sectionTitle}>
+            <h3
+                className={Css.sectionTitle}
+                onClick={() => copyBasicCourseCode(props.section!.identifier)}
+                title={`Click to copy: ${formatCourseCodeForPortal(
+                    props.section!.identifier,
+                )}`}
+            >
                 {(fromActiveTerm
                     ? APIv4.stringifySectionCode
                     : APIv4.stringifySectionCodeLong)(props.section.identifier)}

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -1,0 +1,29 @@
+import type * as APIv4 from "hyperschedule-shared/api/v4";
+import { toast } from "react-toastify";
+
+/**
+ * Formats a course code for portal search: "PHIL144", "PSYC051" (no spaces, zero-padded)
+ */
+export const formatCourseCodeForPortal = (
+    section: APIv4.SectionIdentifier,
+): string => {
+    const paddedNumber = section.courseNumber.toString().padStart(3, "0");
+    return `${section.department}${paddedNumber}`;
+};
+
+/**
+ * Copies a basic course code (department + number only) to clipboard.
+ * Formats for portal search: "PHIL144", "PSYC051" (no spaces, zero-padded)
+ */
+export const copyBasicCourseCode = (section: APIv4.SectionIdentifier): void => {
+    const basicCourseCode = formatCourseCodeForPortal(section);
+
+    navigator.clipboard.writeText(basicCourseCode).then(
+        () => {
+            toast.success(`Copied ${basicCourseCode} to clipboard`);
+        },
+        () => {
+            toast.error("Failed to copy course code");
+        },
+    );
+};


### PR DESCRIPTION
Add click-to-copy functionality for course codes in search results, selected courses list, and section details popup. Course codes are formatted for portal compatibility (e.g., "PHIL144", "PSYC051") with proper zero-padding and no spaces.

- CourseRow: clickable course codes with hover feedback
- SelectedList: copy course codes from user's selected courses
- SectionDetails: copy from detailed course view popup
- clipboard.ts: reusable utilities for formatting and copying

A bit unsure about how to do the actual copying process from a UI/UX perspective, will probably just merge into nightly and see how it is. Currently decided to just have it hover, instead of adding a feather copy icon. Adding the feather copy icon creates a bit of an ugly gap / layout shift, which could be remedied by some sort of fixed width, but I was too lazy to get that working tbh. 
