### PR TITLE
Reduce copy area to just be width of the text and align course code with course name on mobile

### DIFF
--- a/frontend/src/components/course-search/CourseRow.module.css
+++ b/frontend/src/components/course-search/CourseRow.module.css
@@ -40,6 +40,10 @@
         display: grid;
         grid-template-areas: "code" "title";
         align-items: center;
+
+        & .title {
+            padding: 0 0.25rem;
+        }
     }
 
     & .status {
@@ -60,6 +64,10 @@
         & .summary {
             grid-template-areas: "code title";
             justify-content: left;
+
+            & .title {
+                padding: 0;
+            }
         }
 
         & .status {
@@ -133,12 +141,17 @@
             width: 5.5ex;
         }
 
+        & .courseNumberContainer {
+            display: flex;
+            min-width: 8.5em;
+            justify-content: space-between;
+        }
+
         & .courseNumber {
             margin-right: 0.5em;
             font-weight: 700;
             font-size: 0.875em;
             opacity: 0.875;
-            min-width: 8.5em;
             text-align: left;
             cursor: pointer;
             padding: 0.125rem 0.25rem;

--- a/frontend/src/components/course-search/CourseRow.tsx
+++ b/frontend/src/components/course-search/CourseRow.tsx
@@ -229,12 +229,16 @@ const CopyCodeSpan = memo(function CopyCodeSpan(props: {
     };
 
     return (
-        <span
-            className={Css.courseNumber}
-            onClick={handleCopy}
-            title={`Click to copy: ${formatCourseCodeForPortal(props.section)}`}
-        >
-            {APIv4.stringifySectionCode(props.section)}
+        <span className={Css.courseNumberContainer}>
+            <span
+                className={Css.courseNumber}
+                onClick={handleCopy}
+                title={`Click to copy: ${formatCourseCodeForPortal(
+                    props.section,
+                )}`}
+            >
+                {APIv4.stringifySectionCode(props.section)}
+            </span>
         </span>
     );
 });

--- a/shared/lib/schema.ts
+++ b/shared/lib/schema.ts
@@ -84,8 +84,8 @@ export type MethodFetch<Schema extends MethodSchemaAny> =
     Schema extends MethodSchemaPostAny
         ? MethodFetchPost<Schema>
         : Schema extends MethodSchemaGetAny
-          ? MethodFetchGet<Schema>
-          : never;
+        ? MethodFetchGet<Schema>
+        : never;
 
 export type RouteFetch<
     Schema extends RouteSchemaAny,


### PR DESCRIPTION
First, this reduces the copy code area to just what the width of the text is. This makes it a bit more predictable for the user. I did it with a flex box but perhaps there is a better way.

Also aligns the title and course code by setting the title to have the same x-padding on mobile.
<img width="192" height="57" alt="Screenshot 2025-10-27 at 11 07 22 AM" src="https://github.com/user-attachments/assets/b0247ea8-6d73-4b72-9d2f-56165742dade" />

And the formatter wanted to change schema.ts and wouldn't let me commit if I didn't :(