### PR TITLE
Fix double allocation of 8080 in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,8 +50,6 @@ services:
             db:
                 condition:
                     service_started
-        ports:
-            - 8080:8080
         networks:
             - backend
         volumes:


### PR DESCRIPTION
This removes the port 8080 from the backend docker config. My understanding is that the nginx also declares that it uses 8080 and proxys that traffic to the backend so exposing the backend itself to the host is not necessary. When trying to run in the current state (on my mac), it errors:
```
Error response from daemon: failed to set up container networking: driver failed programming external connectivity on endpoint hyperschedule-nginx-1 (94dacbd83a803d3bf448ba0e271834fabe44f41d9cbff0230aa8774d86709e80): Bind for 0.0.0.0:8080 failed: port is already allocated
```